### PR TITLE
Added dynamic route paramters

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -24,7 +24,7 @@ ReactDOM.render(
         <Route path="/login" exact render={(props) => <Login {...props} />} />
         <Route path="/signup" exact render={(props) => <Signup {...props} />} />
         <Route
-          path="/property-result"
+          path="/property-result/:id"
           render={(props) => <PropertyResult {...props} />}
         />
       </Switch>

--- a/client/src/views/PropertyResult/PropertyResult.jsx
+++ b/client/src/views/PropertyResult/PropertyResult.jsx
@@ -13,7 +13,7 @@ const PropertyResult = ({ match }) => {
   const [topRating, setTopRating] = useState(null);
 
   const getDetails = () => {
-    const body = JSON.stringify({ id: 1 });
+    const body = JSON.stringify({ id: match.params.id });
     fetch('http://localhost:3000/propertyprofile', {
       method: 'POST',
       headers: {


### PR DESCRIPTION
Problem: The PropertyResult component was not grabbing the property ID from its route parameters and was using a hardcoded ID of '1' to fetch the data for Codesmith. This meant it could not possibly fetch data for any other location.

Solution: The <Route /> for /property-result was missed a '/:id' dynamic parameter. After adding that we can now properly destructure that inside of PropertyResult.jsx and then fire a fetch request for any property ID.

To test: Search for any property and then view the results on the /property-result page (which you should automatically be redirected to).